### PR TITLE
feat: define resolve-file Cargo feature to support WASM in the browser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,11 @@ serde_yaml = "0.9"
 ureq = "2"
 criterion = "0.4"
 
+[features]
+# Enable resolution of file resources. Disable to support WASM in the browser.
+resolve-file = []
+default = ["resolve-file"]
+
 [[bench]]
 name = "bench"
 harness = false

--- a/src/draft.rs
+++ b/src/draft.rs
@@ -318,12 +318,16 @@ fn load_std_metaschemas() -> Result<Schemas, CompileError> {
     let mut schemas = Schemas::new();
     let mut compiler = Compiler::new();
     compiler.enable_format_assertions();
-    compiler.compile("https://json-schema.org/draft/2020-12/schema", &mut schemas)?;
-    compiler.compile("https://json-schema.org/draft/2019-09/schema", &mut schemas)?;
-    compiler.compile("http://json-schema.org/draft-07/schema", &mut schemas)?;
-    compiler.compile("http://json-schema.org/draft-06/schema", &mut schemas)?;
-    compiler.compile("http://json-schema.org/draft-04/schema", &mut schemas)?;
+    compiler.compile_url(try_url("https://json-schema.org/draft/2020-12/schema")?, &mut schemas)?;
+    compiler.compile_url(try_url("https://json-schema.org/draft/2019-09/schema")?, &mut schemas)?;
+    compiler.compile_url(try_url("http://json-schema.org/draft-07/schema")?, &mut schemas)?;
+    compiler.compile_url(try_url("http://json-schema.org/draft-06/schema")?, &mut schemas)?;
+    compiler.compile_url(try_url("http://json-schema.org/draft-04/schema")?, &mut schemas)?;
     Ok(schemas)
+}
+
+fn try_url(url: &str) -> Result<Url, CompileError> {
+    Url::parse(url).map_err(Into::into)
 }
 
 #[cfg(test)]
@@ -339,7 +343,7 @@ mod tests {
         let v: Value = serde_json::from_str(include_str!("metaschemas/draft-04/schema")).unwrap();
         let url = "https://json-schema.org/draft-04/schema";
         compiler.add_resource(url, v).unwrap();
-        compiler.compile(url, &mut schemas).unwrap();
+        compiler.compile_url(try_url(url).unwrap(), &mut schemas).unwrap();
     }
 
     #[test]

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -14,8 +14,10 @@ pub trait UrlLoader {
 
 // --
 
+#[cfg(feature = "resolve-file")]
 struct FileLoader;
 
+#[cfg(feature = "resolve-file")]
 impl UrlLoader for FileLoader {
     fn load(&self, url: &str) -> Result<Value, Box<dyn Error>> {
         let url = Url::parse(url)?;
@@ -32,6 +34,7 @@ pub(crate) struct DefaultUrlLoader(HashMap<&'static str, Box<dyn UrlLoader>>);
 impl DefaultUrlLoader {
     pub fn new() -> Self {
         let mut v = Self(Default::default());
+        #[cfg(feature = "resolve-file")]
         v.0.insert("file", Box::new(FileLoader));
         v
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -20,6 +20,7 @@ fn starts_with_windows_drive(p: &str) -> bool {
     p.chars().next().filter(char::is_ascii_uppercase).is_some() && p[1..].starts_with(":\\")
 }
 
+#[cfg(feature = "resolve-file")]
 pub(crate) fn to_url(s: &str) -> Result<Url, CompileError> {
     debug_assert!(!s.contains('#'));
 

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -58,6 +58,28 @@ fn example_from_strings() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+fn example_without_files() -> Result<(), Box<dyn Error>> {
+    let cat_schema: Value = json!({
+        "type": "object",
+        "properties": {
+            "speak": { "const": "meow" }
+        },
+        "required": ["speak"]
+    });
+    let instance: Value = json!({"speak": "meow"});
+
+    let mut schemas = Schemas::new();
+    let mut compiler = Compiler::new();
+    let uri = Url::parse("uri://cat")?;
+    compiler.add_resource_url(uri.clone(), cat_schema)?;
+    let sch_index = compiler.compile_url(uri, &mut schemas)?;
+    let result = schemas.validate(&instance, sch_index);
+    assert!(result.is_ok());
+
+    Ok(())
+}
+
+#[test]
 #[ignore]
 fn example_from_https() -> Result<(), Box<dyn Error>> {
     let schema_url = "https://json-schema.org/learn/examples/geographical-location.schema.json";

--- a/tests/filepaths.rs
+++ b/tests/filepaths.rs
@@ -1,3 +1,5 @@
+
+#![cfg(feature = "resolve-file")]
 use std::fs;
 
 use boon::{CompileError, Compiler, Schemas};


### PR DESCRIPTION
Define a cargo feature "resolve-file" for resolving file resources. The feature is enabled by default.
It can be disabled for targets without file path support, e.g. browser WASM.

Issue #5