### PR TITLE
Changed example code to use Bufreader instead of Reader

### DIFF
--- a/examples/boon.rs
+++ b/examples/boon.rs
@@ -1,4 +1,4 @@
-use std::{env, error::Error, fs::File, process, str::FromStr};
+use std::{env, error::Error, fs::File, io::BufReader, process, str::FromStr};
 
 use boon::{Compiler, Draft, Schemas, UrlLoader};
 use getopts::Options;
@@ -104,7 +104,7 @@ fn main() {
             println!();
         }
         let rdr = match File::open(instance) {
-            Ok(rdr) => rdr,
+            Ok(rdr) => BufReader::new(rdr),
             Err(e) => {
                 println!("instance {instance}: failed");
                 if !quiet {


### PR DESCRIPTION
First, thank you for this incredible library. 🦀🦀🦀

While using the CLI version at work, I found that our CI/CD was timing out. 
Digging in, it looks like like the use of a Reader _massively_ increases the amount of Read calls that are made. 
As read syscalls take up a majority of the programs time, I suggest switching this out to a bufreader so that folks using the CLI out of the box do not run into similar issues.

**Reader**
```
$ strace -c /opt/fst-boon/fst-boon -d jsonschemadraft some.json someother.json
schema some.json: ok
instance someother.json: ok
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 99.98   12.170442           1   8507825           read
```

**Bufreader**
```
$ strace -c /opt/fst-boon/fst-boon -d jsonschemadraft some.json someother.json
schema some.json: ok
instance someother.json: ok
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 95.25    0.005049           1      4344           read
```
