### PR TITLE
FileLoader was always used in lib, even on wasm

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,4 +45,15 @@ jobs:
       run: cargo doc
       env:
         RUSTFLAGS: -D warnings
-      
+  wasm:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout repo
+      uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        target: wasm32-unknown-emscripten
+    - name: Check
+      run: cargo check --target wasm32-unknown-emscripten

--- a/src/formats.rs
+++ b/src/formats.rs
@@ -215,7 +215,7 @@ fn check_date_time(s: &str) -> Result<(), Box<dyn Error>> {
     if s.len() < 20 {
         Err("less than 20 characters long")?;
     }
-    if !s.is_char_boundary(10) || !s[10..].starts_with(|c| matches!(c, 't' | 'T')) {
+    if !s.is_char_boundary(10) || !s[10..].starts_with(['t', 'T']) {
         Err("11th character must be t or T")?;
     }
     if let Err(e) = check_date(&s[..10]) {
@@ -606,7 +606,7 @@ fn check_email(s: &str) -> Result<(), Box<dyn Error>> {
     if local.len() > 1 && local.starts_with('"') && local.ends_with('"') {
         // quoted
         let local = &local[1..local.len() - 1];
-        if local.contains(|c| matches!(c, '\\' | '"')) {
+        if local.contains(['\\', '"']) {
             Err("backslash and quote not allowed within quoted local part")?
         }
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,11 +114,13 @@ mod roots;
 mod util;
 mod validator;
 
+#[cfg(not(target_arch = "wasm32"))]
+pub use loader::FileLoader;
 pub use {
     compiler::{CompileError, Compiler, Draft},
     content::{Decoder, MediaType},
     formats::Format,
-    loader::{FileLoader, SchemeUrlLoader, UrlLoader},
+    loader::{SchemeUrlLoader, UrlLoader},
     output::{
         AbsoluteKeywordLocation, FlagOutput, KeywordPath, OutputError, OutputUnit, SchemaToken,
     },

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -80,6 +80,7 @@ pub(crate) struct DefaultUrlLoader {
 }
 
 impl DefaultUrlLoader {
+    #[cfg_attr(target_arch = "wasm32", allow(unused_mut))]
     pub fn new() -> Self {
         let mut loader = SchemeUrlLoader::new();
         #[cfg(not(target_arch = "wasm32"))]

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,7 +2,6 @@ use std::{
     borrow::{Borrow, Cow},
     fmt::Display,
     hash::{Hash, Hasher},
-    path,
     str::FromStr,
 };
 
@@ -220,7 +219,7 @@ impl UrlFrag {
             Ok(url) => Ok(UrlFrag { url, frag }),
             #[cfg(not(target_arch = "wasm32"))]
             Err(url::ParseError::RelativeUrlWithoutBase) => {
-                let p = path::absolute(u).map_err(|e| CompileError::ParseUrlError {
+                let p = std::path::absolute(u).map_err(|e| CompileError::ParseUrlError {
                     url: u.to_owned(),
                     src: e.into(),
                 })?;
@@ -307,6 +306,7 @@ pub(crate) fn is_integer(v: &Value) -> bool {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn starts_with_windows_drive(p: &str) -> bool {
     p.chars().next().filter(char::is_ascii_uppercase).is_some() && p[1..].starts_with(":\\")
 }


### PR DESCRIPTION
This PR puts the `FileLoader` use behind a `target_arch` gate, and adds a CI rachet. Includes some fixup commits to do more conditional compilation and correct some **clippy** nits.